### PR TITLE
Fix: Resolve 404 errors for /trips/ and clarify /parks/ routing.

### DIFF
--- a/park_logger/trips/templates/trips/trip_list.html
+++ b/park_logger/trips/templates/trips/trip_list.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}My Trips{% endblock %}
+
+{% block content %}
+<h1>My Trips</h1>
+{% if trips %}
+    <ul>
+    {% for trip in trips %}
+        <li>{{ trip.name }} - {{ trip.visit_date|date:"Y-m-d" }}</li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>No trips recorded yet.</p>
+{% endif %}
+{% endblock %}

--- a/park_logger/trips/urls.py
+++ b/park_logger/trips/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import ParkListView, ParkDetailView, TripCreateView, ajax_get_nearby_parks
+from .views import ParkListView, ParkDetailView, TripCreateView, ajax_get_nearby_parks, TripListView
 
 app_name = 'trips'
 
 urlpatterns = [
+    path('', TripListView.as_view(), name='trip_list'),
     path('parks/', ParkListView.as_view(), name='park_list'),
     path('parks/<int:pk>/', ParkDetailView.as_view(), name='park_detail'),
     path('trip/add/', TripCreateView.as_view(), name='trip_add'), # New URL for adding trips

--- a/park_logger/trips/views.py
+++ b/park_logger/trips/views.py
@@ -30,6 +30,12 @@ class ParkDetailView(DetailView):
         context['trips'] = Trip.objects.filter(park=self.object).order_by('-visit_date')
         return context
 
+class TripListView(ListView):
+    model = Trip
+    template_name = 'trips/trip_list.html'
+    context_object_name = 'trips'
+    queryset = Trip.objects.all().order_by('-visit_date')
+
 class TripCreateView(CreateView):
     model = Trip
     form_class = TripForm


### PR DESCRIPTION
- Added TripListView and template to handle requests for the `/trips/` URL. This view lists all trips and is accessible at `/trips/`.
- Added a new URL pattern in `trips/urls.py` for the `TripListView` at the empty path, resolving the 404 error for `/trips/`.

- Confirmed that the `/parks/` URL is correctly configured as `/trips/parks/`. The previous 404 error for `/parks/` was due to requests being made to the root `/parks/` path instead of the namespaced `/trips/parks/` path. No changes to this specific URL pattern were needed as it was already correct.

All URLs under the `/trips/` namespace, including the new `/trips/` path and existing paths like `/trips/parks/`, are now correctly routed.